### PR TITLE
add build support for Python v3.12

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -77,7 +77,7 @@ jobs:
 
         - name: Build wheels on linux
           if: ${{ matrix.buildplat[1] == 'manylinux' }}
-          uses: pypa/cibuildwheel@v2.11.4
+          uses: pypa/cibuildwheel@v2.16.2
           env:
             CIBW_ENVIRONMENT: PATH=$(pwd)/go/bin:$PATH
             CIBW_BEFORE_BUILD: sh pre-build-command.sh
@@ -87,7 +87,7 @@ jobs:
 
         - name: Build wheels on macos
           if: ${{ matrix.buildplat[1] == 'macosx' }}
-          uses: pypa/cibuildwheel@v2.11.4
+          uses: pypa/cibuildwheel@v2.16.2
           env:
             CIBW_ENVIRONMENT: PATH=$(pwd)/go/bin:$PATH
             CIBW_BEFORE_BUILD: sh pre-build-command.sh

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
 
@@ -61,7 +61,7 @@ jobs:
           buildplat:
           - [ubuntu-latest, manylinux, "x86_64 aarch64"]
           - [macos-latest, macosx, x86_64]
-          python: ["cp37", "cp38", "cp39", "cp310", "cp311"]
+          python: ["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"]
 
       steps:
         - name: Checkout

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Python wrapper for [hashicorp/hcl](https://github.com/hashicorp/hcl) (v2).
 
 ## Requirements
-The following versions are supported - 3.6, 3.7, 3.8, 3.9, 3.10, 3.11.
+The following versions are supported - 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12.
 
 ## Setup
 ```sh

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,6 +10,7 @@ pycparser==2.20
 pyelftools==0.26
 pyparsing==2.4.7
 pytest==7.2.0
+setuptools==69.0.2 ; python_version >= "3.12"
 six==1.14.0
 wcwidth==0.1.9
 zipp==3.1.0


### PR DESCRIPTION
Collection of various changes to make this module work with Python 3.12.

- [x] adds Python 3.12 to test and build workflows
- [x] installs `setuptools` only for Python v3.12+ as v3.12 removed `distutils` which is now part of `setuptools`, cf. <https://docs.python.org/3/whatsnew/3.12.html>
- [x] updates the `cibuildwheel` action to the latest version for Python 3.12 support
- [x] tests are still passing 