### PR TITLE
Fix complex types parsing in attributes_load

### DIFF
--- a/pygohcl.go
+++ b/pygohcl.go
@@ -63,7 +63,7 @@ func ParseAttributes(a *C.char) (resp C.parseResponse) {
 
 	var diags hcl.Diagnostics
 	hclMap := make(jsonObj)
-	c := converter{}
+	c := converter{[]byte(input)}
 
 	attrs, attrsDiags := hclFile.Body.JustAttributes()
 	diags = diags.Extend(attrsDiags)

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -85,3 +85,61 @@ you
 EOT
     """
     assert pygohcl.attributes_loads(s) == {"var": "hey\nyou\n"}
+
+
+def test_complex_objects():
+    s = """
+    var = [
+        {
+            a = 1
+            b = 2
+        },
+        {
+            a = "1"
+            b = false
+        },
+        {
+            a = [1, 2, 3]
+            b = [4, 5, 6]
+        },
+        {
+            c = {
+                a = 1
+                b = [true, false]
+            }
+        }
+    ]
+    """
+    assert pygohcl.attributes_loads(s) == {
+        "var": [
+            {
+                "a": 1,
+                "b": 2,
+            },
+            {
+                "a": "1",
+                "b": False,
+            },
+            {
+                "a": [
+                    1,
+                    2,
+                    3,
+                ],
+                "b": [
+                    4,
+                    5,
+                    6,
+                ],
+            },
+            {
+                "c": {
+                    "a": 1,
+                    "b": [
+                        True,
+                        False,
+                    ],
+                },
+            },
+        ]
+    }


### PR DESCRIPTION
Fixes `pygohcl.HCLParseError: panic HCL: runtime error: slice bounds out of range` when parsing complex structures.