### PR TITLE
SCALRCORE-32265 Agent > Update Go dependencies

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.22.3"
+          go-version: "1.22.7"
 
       - name: Install dependencies
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalr/pygohcl
 
-go 1.22.3
+go 1.22
 
 require (
 	github.com/hashicorp/hcl/v2 v2.22.0

--- a/pre-build-command.sh
+++ b/pre-build-command.sh
@@ -24,11 +24,10 @@ case $ARCH in
     *arm64)   ARCH="arm64" ;;
     *aarch64) ARCH="arm64" ;;
 esac
-curl "https://storage.googleapis.com/golang/go1.22.3.${OS}-${ARCH}.tar.gz" --silent --location | tar -xz
+curl "https://storage.googleapis.com/golang/go1.22.7.${OS}-${ARCH}.tar.gz" --silent --location | tar -xz
 export PATH="$(pwd)/go/bin:$PATH"
 
 echo "OS: $(uname -a)"
-echo "GO=go1.22.3.${OS}-${ARCH}.tar.gz"
+echo "GO=go1.22.7.${OS}-${ARCH}.tar.gz"
 echo "ARCH=$ARCH"
 echo "PATH=$PATH"
-


### PR DESCRIPTION
Addressing CVE-2024-24787, CVE-2024-24790.
Planned for a v1.2.1 release.